### PR TITLE
Add remote Pokémon data fallback via PokeAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ List available tools and resources using the MCP client of your choice. This ser
 - Resource `pokemon`
 - Tool `simulate_battle`
 
+## Pokémon Data Resource
+
+The `pokemon` resource follows the MCP resource pattern. It lists available
+Pokémon and returns full details for each entry. When a Pokémon is not present
+in the bundled dataset, the resource connects to the public [PokeAPI](https://pokeapi.co/)
+to retrieve up-to-date information including base stats, types, abilities, moves
+and evolution data.
+
 ## Examples
 
 Fetch a Pokémon:
@@ -32,6 +40,12 @@ from core.repository import get_pokemon
 
 res = PokemonResource()
 print(res.get("Pikachu"))
+```
+
+Querying a Pokémon not in the local dataset triggers a fetch from PokeAPI:
+
+```python
+res.get("Lucario")
 ```
 
 Simulate a battle:
@@ -50,7 +64,8 @@ Determinism is guaranteed through a seed parameter (default 42). Reusing the sam
 
 ## Data
 
-All datasets are stored locally under `data/` and compiled from public information.
+Core datasets are stored locally under `data/` and compiled from public information.
+When a requested Pokémon or move is missing, data is fetched live from PokeAPI.
 Pokémon and names are trademarks of Nintendo and Game Freak.
 
 Example `pokemon` resource call:

--- a/core/repository.py
+++ b/core/repository.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import requests
+
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 
 
@@ -24,11 +26,71 @@ def get_pokemon(identifier: str | int) -> Optional[Dict[str, Any]]:
             return dict(p)
         if isinstance(identifier, str) and p["name"].lower() == identifier.lower():
             return dict(p)
-    return None
+
+    # Fallback to the public PokeAPI if the Pokémon is not in the local index
+    name = str(identifier).lower()
+    try:
+        resp = requests.get(f"https://pokeapi.co/api/v2/pokemon/{name}", timeout=10)
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        stats = {
+            s["stat"]["name"].replace("-", "_"): s["base_stat"] for s in data["stats"]
+        }
+        abilities = [
+            a["ability"]["name"].replace("-", " ").title() for a in data["abilities"]
+        ]
+        types = [t["type"]["name"] for t in data["types"]]
+        move_names = [m["move"]["name"].replace("-", " ").title() for m in data["moves"][:4]]
+        evo = get_evolution(data["name"])
+        return {
+            "id": data["id"],
+            "name": data["name"].title(),
+            "types": types,
+            "base_stats": {
+                "hp": stats.get("hp"),
+                "atk": stats.get("attack"),
+                "def": stats.get("defense"),
+                "sp_atk": stats.get("special_attack"),
+                "sp_def": stats.get("special_defense"),
+                "speed": stats.get("speed"),
+            },
+            "abilities": abilities,
+            "moves": move_names,
+            "evolution": evo,
+        }
+    except Exception:
+        return None
 
 
 def get_move(name: str) -> Optional[Dict[str, Any]]:
-    return _MOVES.get(name)
+    move = _MOVES.get(name)
+    if move:
+        return move
+
+    api_name = name.lower().replace(" ", "-")
+    try:
+        resp = requests.get(f"https://pokeapi.co/api/v2/move/{api_name}", timeout=10)
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        effect = None
+        for entry in data.get("effect_entries", []):
+            if entry["language"]["name"] == "en":
+                effect = entry.get("short_effect")
+                break
+        move = {
+            "name": data["name"].replace("-", " ").title(),
+            "type": data["type"]["name"],
+            "power": data["power"],
+            "category": data["damage_class"]["name"],
+            "accuracy": data["accuracy"],
+            "effect": effect,
+        }
+        _MOVES[move["name"]] = move
+        return move
+    except Exception:
+        return None
 
 
 def list_pokemon() -> List[Dict[str, Any]]:
@@ -36,4 +98,40 @@ def list_pokemon() -> List[Dict[str, Any]]:
 
 
 def get_evolution(name: str) -> Dict[str, Any]:
-    return _EVOS.get(name, {})
+    evo = _EVOS.get(name)
+    if evo:
+        return evo
+
+    # Query PokeAPI for evolution data
+    try:
+        resp = requests.get(
+            f"https://pokeapi.co/api/v2/pokemon-species/{name.lower()}", timeout=10
+        )
+        if resp.status_code != 200:
+            return {}
+        species = resp.json()
+        result: Dict[str, Any] = {}
+        if species.get("evolves_from_species"):
+            result["pre"] = species["evolves_from_species"]["name"].title()
+
+        chain_resp = requests.get(species["evolution_chain"]["url"], timeout=10)
+        chain = chain_resp.json()["chain"]
+
+        def _find(chain: Dict[str, Any]) -> List[str]:
+            if chain["species"]["name"] == name.lower():
+                return [e["species"]["name"] for e in chain["evolves_to"]]
+            for e in chain["evolves_to"]:
+                res = _find(e)
+                if res:
+                    return res
+            return []
+
+        next_evos = _find(chain)
+        if next_evos:
+            formatted = [n.title() for n in next_evos]
+            result["next"] = formatted[0] if len(formatted) == 1 else formatted
+
+        _EVOS[name] = result
+        return result
+    except Exception:
+        return {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mcp>=0.1.0
 pydantic>=2.0
 pytest
+requests


### PR DESCRIPTION
## Summary
- fetch missing Pokémon, moves, and evolution data from PokeAPI
- document Pokémon resource behavior and remote fetching
- add requests dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f38810c28832da2bbfc3376afe3a2