### PR TITLE
feat(mcp): add FastMCP adapter server

### DIFF
--- a/legacy_server.py
+++ b/legacy_server.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pokemon_mcp.server import Server
+
+server = Server("mcp-pokemon")
+
+# register resources and tools
+import pokemon_mcp.resources  # noqa: F401
+import pokemon_mcp.tools  # noqa: F401
+
+
+if __name__ == "__main__":
+    server.run()

--- a/pokemon_mcp/resources.py
+++ b/pokemon_mcp/resources.py
@@ -6,7 +6,7 @@ from pokemon_mcp.server import Resource
 
 from core.repository import get_evolution, get_move, get_pokemon, list_pokemon
 from .schemas import PokemonDetail, PokemonSummary
-from server import server
+from legacy_server import server
 
 
 @server.resource("pokemon")

--- a/pokemon_mcp/tools.py
+++ b/pokemon_mcp/tools.py
@@ -4,7 +4,7 @@ from pokemon_mcp.server import Tool
 
 from core.repository import get_pokemon
 from core.turn_engine import simulate_battle
-from server import server
+from legacy_server import server
 from .schemas import SimulateRequest, SimulateResponse
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp>=0.1.0
+mcp[cli]>=0.1.0
 pydantic>=2.0
 pytest
 requests

--- a/server.py
+++ b/server.py
@@ -1,13 +1,88 @@
 from __future__ import annotations
 
-from pokemon_mcp.server import Server
+from mcp.server.fastmcp import FastMCP
 
-server = Server("mcp-pokemon")
+# Existing domain functions and models
+from core.repository import get_evolution, get_move, get_pokemon, list_pokemon
 
-# register resources and tools
-import pokemon_mcp.resources  # noqa: F401
-import pokemon_mcp.tools  # noqa: F401
+try:
+    # Pydantic v2 models preferred
+    from pokemon_mcp.schemas import PokemonDetail, PokemonSummary
+    V2 = hasattr(PokemonDetail, "model_dump")
+except Exception:
+    raise
+
+server = FastMCP()
+
+def _to_dict(model: object) -> dict:
+    """Return JSON-serializable dict regardless of Pydantic v2/v1."""
+    if hasattr(model, "model_dump"):
+        return model.model_dump()
+    if hasattr(model, "dict"):
+        return model.dict()
+    return dict(model)
 
 
-if __name__ == "__main__":
-    server.run()
+@server.resource("pokemon://list")
+async def list_pokemon_resource() -> dict:
+    """Return a list of Pokemon summaries."""
+    items: list[dict] = [
+        _to_dict(PokemonSummary(id=p["id"], name=p["name"], types=p["types"]))
+        for p in list_pokemon()
+    ]
+    return {"items": items}
+
+
+@server.resource("pokemon://detail/{id}")
+async def get_pokemon_resource(id: str) -> dict:
+    """Return a Pokemon detail by numeric ID or name."""
+    key = int(id) if id.isdigit() else id
+    p = get_pokemon(key)
+    if not p:
+        raise ValueError(f"Pokemon '{id}' not found")
+
+    moves = [m for m in (get_move(mk) for mk in p["moves"]) if m]
+    types = [t.capitalize() for t in p["types"]]
+    evo = get_evolution(p["name"])
+
+    detail = PokemonDetail(
+        id=p["id"],
+        name=p["name"],
+        types=types,
+        base_stats=p["base_stats"],
+        abilities=p["abilities"],
+        moves=moves,
+        evolution=evo,
+    )
+    return _to_dict(detail)
+
+
+@server.tool()
+async def simulate_battle(
+    pokemonA: str,
+    pokemonB: str,
+    level: int = 50,
+    seed: int = 42,
+    maxTurns: int = 200,
+) -> dict:
+    """
+    Run a full battle simulation and return a structured result:
+    {"winner": str, "turns": int, "log": List[...]}
+    """
+    from pokemon_mcp.tools import simulate_battle_tool
+    from pokemon_mcp.schemas import SimulateRequest
+
+    req = SimulateRequest(
+        pokemonA=pokemonA,
+        pokemonB=pokemonB,
+        level=level,
+        seed=seed,
+        maxTurns=maxTurns,
+    )
+    res = simulate_battle_tool(req)
+
+    return {
+        "winner": getattr(res, "winner", None),
+        "turns": getattr(res, "turns", None),
+        "log": getattr(res, "log", []),
+    }


### PR DESCRIPTION
## Summary
- add FastMCP entrypoint exposing pokemon://list, pokemon://detail/{id}, and battle simulation tool
- keep legacy server under legacy_server.py and update imports
- include `mcp[cli]` extra for CLI support

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `mcp dev server.py`

------
https://chatgpt.com/codex/tasks/task_e_689fb078ce74832d96e64c3b546079f4