### PR TITLE
Add battle-strategy prompt using OpenAI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
   "mcp>=0.1.0",
-  "pydantic>=2.0"
+  "pydantic>=2.0",
+  "openai"
 ]
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mcp[cli]>=0.1.0
 pydantic>=2.0
 pytest
 requests
+openai


### PR DESCRIPTION
## Summary
- add `battle-strategy` prompt that queries OpenAI for matchup strategies
- configure OpenAI import and placeholder API key
- include `openai` dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d46f4850832d9e7a7954db98769e