### PR TITLE
Fix AssistantMessage NameError in server prompt

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from mcp.server.fastmcp import FastMCP
 import openai
 from mcp.server.fastmcp.prompts.base import AssistantMessage


### PR DESCRIPTION
## Summary
- ensure `AssistantMessage` type resolves by removing postponed annotations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0efe1de80832d9b97bc9bad5a9b5a