### PR TITLE
Fix FastMCP message schema for prompts

### DIFF
--- a/server.py
+++ b/server.py
@@ -94,24 +94,21 @@ async def simulate_battle(
 @server.prompt("battle-strategy")
 def battle_strategy(pokemonA: str, pokemonB: str) -> list[Message]:
     system_msg = Message(
-        role="system",
-        content=[
-            TextContent(
-                type="text",
-                text=(
-                    "You are a concise, tactical Pokémon battle analyst. "
-                    "Favor accurate type matchups, realistic movesets, and step-by-step reasoning."
-                ),
-            )
-        ],
+        role="assistant",
+        content=TextContent(
+            type="text",
+            text=(
+                "You are a concise, tactical Pokémon battle analyst. "
+                "Favor accurate type matchups, realistic movesets, and step-by-step reasoning."
+            ),
+        ),
     )
     user_msg = Message(
         role="user",
-        content=[
-            TextContent(
-                type="text",
-                text=(
-                    f"""
+        content=TextContent(
+            type="text",
+            text=(
+                f"""
 Analyze {pokemonA} vs {pokemonB}.
 1) Types, key resistances/immunities, and expected effectiveness.
 2) 3–4 optimal moves each (move name + why).
@@ -120,9 +117,8 @@ Analyze {pokemonA} vs {pokemonB}.
 5) Likely win path for each side and one high-risk tech option.
 Return a compact plan with bullet points and a final one-paragraph verdict.
 """
-                ),
-            )
-        ],
+            ),
+        ),
     )
     return [system_msg, user_msg]
 
@@ -130,16 +126,18 @@ Return a compact plan with bullet points and a final one-paragraph verdict.
 @server.prompt("move-explainer")
 def move_explainer(moveName: str) -> list[Message]:
     system_msg = Message(
-        role="system",
-        content=[TextContent(type="text", text="You are a Pokémon move encyclopedia, explaining mechanics clearly.")],
+        role="assistant",
+        content=TextContent(
+            type="text",
+            text="You are a Pokémon move encyclopedia, explaining mechanics clearly.",
+        ),
     )
     user_msg = Message(
         role="user",
-        content=[
-            TextContent(
-                type="text",
-                text=(
-                    f"""
+        content=TextContent(
+            type="text",
+            text=(
+                f"""
 Explain the move: {moveName}.
 Include:
 - Type and category (physical/special/status)
@@ -149,9 +147,8 @@ Include:
 - Notable Pokémon that learn it
 Return a structured explanation in bullet points.
 """
-                ),
-            )
-        ],
+            ),
+        ),
     )
     return [system_msg, user_msg]
 
@@ -159,16 +156,18 @@ Return a structured explanation in bullet points.
 @server.prompt("evolution-guide")
 def evolution_guide(pokemonName: str) -> list[Message]:
     system_msg = Message(
-        role="system",
-        content=[TextContent(type="text", text="You are a knowledgeable Pokémon professor explaining evolutions.")],
+        role="assistant",
+        content=TextContent(
+            type="text",
+            text="You are a knowledgeable Pokémon professor explaining evolutions.",
+        ),
     )
     user_msg = Message(
         role="user",
-        content=[
-            TextContent(
-                type="text",
-                text=(
-                    f"""
+        content=TextContent(
+            type="text",
+            text=(
+                f"""
 Explain how {pokemonName} evolves.
 Include:
 - Evolution chain with names
@@ -176,9 +175,8 @@ Include:
 - Competitive implications of each stage
 - One interesting trivia fact
 """
-                ),
-            )
-        ],
+            ),
+        ),
     )
     return [system_msg, user_msg]
 
@@ -186,16 +184,18 @@ Include:
 @server.prompt("type-matchup")
 def type_matchup(typeA: str, typeB: str) -> list[Message]:
     system_msg = Message(
-        role="system",
-        content=[TextContent(type="text", text="You are a Pokémon type chart analyst.")],
+        role="assistant",
+        content=TextContent(
+            type="text",
+            text="You are a Pokémon type chart analyst.",
+        ),
     )
     user_msg = Message(
         role="user",
-        content=[
-            TextContent(
-                type="text",
-                text=(
-                    f"""
+        content=TextContent(
+            type="text",
+            text=(
+                f"""
 Analyze type matchup: {typeA} vs {typeB}.
 Include:
 - Effectiveness multipliers (super-effective, not very effective, immune)
@@ -203,9 +203,8 @@ Include:
 - Typical strategies when these types face each other
 - Competitive history or common meta insights
 """
-                ),
-            )
-        ],
+            ),
+        ),
     )
     return [system_msg, user_msg]
 
@@ -213,23 +212,24 @@ Include:
 @server.prompt("quick-trivia")
 def quick_trivia(topic: str) -> list[Message]:
     system_msg = Message(
-        role="system",
-        content=[TextContent(type="text", text="You are a fun Pokémon trivia master.")],
+        role="assistant",
+        content=TextContent(
+            type="text",
+            text="You are a fun Pokémon trivia master.",
+        ),
     )
     user_msg = Message(
         role="user",
-        content=[
-            TextContent(
-                type="text",
-                text=(
-                    f"""
+        content=TextContent(
+            type="text",
+            text=(
+                f"""
 Give me 3–4 short trivia facts about {topic}.
 Each fact should be surprising, concise, and accurate.
 End with one one-sentence fun fact.
 """
-                ),
-            )
-        ],
+            ),
+        ),
     )
     return [system_msg, user_msg]
 


### PR DESCRIPTION
## Summary
- use only `assistant`/`user` roles in prompt templates
- pass single `TextContent` objects instead of lists to match FastMCP schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a193a6efc4832da728c248ed33ba2f