### PR TITLE
Expose battle simulator via MCP tool

### DIFF
--- a/docs/prompt_tab.md
+++ b/docs/prompt_tab.md
@@ -1,0 +1,68 @@
+# Prompt Instructions for Battle Simulation
+
+These instructions are loaded into the MCP client's **Prompt** tab. They ensure
+that battle questions always invoke the `simulate_battle` tool and never rely on
+LLM reasoning.
+
+## Core Guidance
+
+1. When the user asks to simulate or play out a Pokémon battle, always call the
+   `simulate_battle` tool exactly once.
+2. Pass the parameters provided by the user. Omit any that are unspecified—the
+   server supplies defaults for `level`, `seed`, and `maxTurns`.
+3. After the tool responds, summarize its JSON output succinctly:
+   - state the `winner` and the number of `turns`;
+   - list **3–6** notable highlights extracted from the `log` entries.
+4. Never fabricate battle outcomes or bypass the tool.
+5. If the tool returns an error (e.g., unknown Pokémon), request corrected names
+   and suggest two valid alternatives.
+
+## Few‑shot Examples
+
+### Example 1
+**User:** "Simulate Bulbasaur vs. Squirtle."
+
+**Assistant (tool call):**
+```json
+{
+  "tool": "simulate_battle",
+  "input": {"pokemonA": "Bulbasaur", "pokemonB": "Squirtle"}
+}
+```
+
+**Tool output:**
+```json
+{"winner": "Squirtle", "turns": 12, "log": […]}
+```
+
+**Assistant (summary):**
+"Squirtle wins after 12 turns. Highlights: Bulbasaur misses a Sleep Powder,
+Squirtle lands a critical Water Gun, Bulbasaur faints from poison."
+
+### Example 2
+**User:** "Run Pikachu against Charmander at level 100 with seed 99."
+
+**Assistant (tool call):**
+```json
+{
+  "tool": "simulate_battle",
+  "input": {
+    "pokemonA": "Pikachu",
+    "pokemonB": "Charmander",
+    "level": 100,
+    "seed": 99
+  }
+}
+```
+
+**Tool output:**
+```json
+{"winner": "Pikachu", "turns": 8, "log": […]}
+```
+
+**Assistant (summary):**
+"Pikachu triumphs in 8 turns. Key moments: Charmander's Ember causes burn,
+Pikachu counters with Thunderbolt, Charmander's HP drops to zero." 
+
+If a Pokémon name is invalid, apologize, suggest two valid Pokémon (e.g.,
+"Bulbasaur" or "Charmander"), and ask the user to resubmit.

--- a/docs/smoke_test.md
+++ b/docs/smoke_test.md
@@ -1,0 +1,19 @@
+# Smoke Test Checklist
+
+Use this checklist to verify the battle simulator MCP integration.
+
+1. **Tool discovery**  
+   Run `mcp dev server.py` and confirm `simulate_battle` appears under the
+   reported Tools.
+2. **Direct invocation**  
+   Send a request with the payload
+   `{ "pokemonA": "Bulbasaur", "pokemonB": "Squirtle" }` to
+   `simulate_battle` and verify JSON output with keys `winner`, `turns` and `log`.
+3. **Prompt Tab behaviour**  
+   In an MCP client, ask "Simulate Bulbasaur vs Squirtle" and ensure the
+   assistant issues a `simulate_battle` tool call rather than a fabricated
+   answer. The summary should mention the winner, number of turns, and a few
+   highlights.
+
+The default parameters keep runtime below two seconds; investigate if responses
+are noticeably slower.

--- a/pokemon_mcp/schemas.py
+++ b/pokemon_mcp/schemas.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+try:
+    from pydantic import BaseModel, Field, ConfigDict  # type: ignore
+    V2 = True
+except Exception:  # pragma: no cover - fall back to pydantic v1
+    from pydantic import BaseModel, Field
+    V2 = False
 
 
 class SimulateRequest(BaseModel):
@@ -11,6 +16,12 @@ class SimulateRequest(BaseModel):
     level: int = Field(50, ge=1, le=100)
     seed: int = 42
     maxTurns: int = 200
+
+    if V2:  # pragma: no branch - configure extra handling for pydantic v2
+        model_config = ConfigDict(extra="forbid")
+    else:  # pragma: no cover - pydantic v1 fallback
+        class Config:
+            extra = "forbid"
 
 
 class LogEntry(BaseModel):

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ from core.repository import get_evolution, get_move, get_pokemon, list_pokemon
 
 try:
     # Pydantic v2 models preferred
-    from pokemon_mcp.schemas import PokemonDetail, PokemonSummary
+    from pokemon_mcp.schemas import PokemonDetail, PokemonSummary, SimulateRequest
     V2 = hasattr(PokemonDetail, "model_dump")
 except Exception:
     raise
@@ -59,34 +59,26 @@ async def get_pokemon_resource(id: str) -> dict:
     return _to_dict(detail)
 
 
-@server.tool()
-async def simulate_battle(
-    pokemonA: str,
-    pokemonB: str,
-    level: int = 50,
-    seed: int = 42,
-    maxTurns: int = 200,
-) -> dict:
-    """
-    Run a full battle simulation and return a structured result:
-    {"winner": str, "turns": int, "log": List[...]}
-    """
+@server.tool(name="simulate_battle")
+async def simulate_battle(params: SimulateRequest) -> dict:
+    """Run a battle simulation and return structured JSON."""
     from pokemon_mcp.tools import simulate_battle_tool
-    from pokemon_mcp.schemas import SimulateRequest
 
-    req = SimulateRequest(
-        pokemonA=pokemonA,
-        pokemonB=pokemonB,
-        level=level,
-        seed=seed,
-        maxTurns=maxTurns,
-    )
-    res = simulate_battle_tool(req)
+    # Apply defaults via the Pydantic model
+    req = SimulateRequest(**params.model_dump())  # ensures defaults for missing fields
+
+    try:
+        res = simulate_battle_tool(req)
+    except Exception as e:  # pragma: no cover - surface as ValueError
+        suggestions = [p["name"] for p in list_pokemon()[:2]]
+        raise ValueError(
+            f"{e}. Try names like {suggestions[0]} or {suggestions[1]}"
+        ) from e
 
     return {
-        "winner": getattr(res, "winner", None),
-        "turns": getattr(res, "turns", None),
-        "log": getattr(res, "log", []),
+        "winner": res.winner,
+        "turns": res.turns,
+        "log": [_to_dict(entry) for entry in res.log],
     }
 
 


### PR DESCRIPTION
## Summary
- expose `simulate_battle` MCP tool with strict schema and error handling
- document prompt instructions forcing tool usage and smoke test checklist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a954e7d4832da5fe9fde5668c66e