### PR TITLE
Refactor battle tool interface and prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,8 @@ Simulate a battle:
 
 ```python
 from pokemon_mcp.tools import simulate_battle_tool
-from pokemon_mcp.schemas import SimulateRequest
 
-req = SimulateRequest(pokemonA="Pikachu", pokemonB="Squirtle", seed=42)
-res = simulate_battle_tool(req)
+res = simulate_battle_tool(pokemonA="Pikachu", pokemonB="Squirtle", seed=42)
 print(res.winner)
 print(res.log[:3])
 ```

--- a/docs/prompt_tab.md
+++ b/docs/prompt_tab.md
@@ -9,7 +9,8 @@ LLM reasoning.
 1. When the user asks to simulate or play out a Pokémon battle, always call the
    `simulate_battle` tool exactly once.
 2. Pass the parameters provided by the user. Omit any that are unspecified—the
-   server supplies defaults for `level`, `seed`, and `maxTurns`.
+   server supplies defaults for `level`, `seed`, and `maxTurns`. Do **not** wrap
+   arguments inside a `params` object; place them directly within `input`.
 3. After the tool responds, summarize its JSON output succinctly:
    - state the `winner` and the number of `turns`;
    - list **3–6** notable highlights extracted from the `log` entries.

--- a/pokemon_mcp/tools.py
+++ b/pokemon_mcp/tools.py
@@ -9,8 +9,34 @@ from .schemas import SimulateRequest, SimulateResponse
 
 
 @server.tool("simulate_battle")
-def simulate_battle_tool(params: SimulateRequest) -> SimulateResponse:
-    a = get_pokemon(params.pokemonA)
-    b = get_pokemon(params.pokemonB)
-    result = simulate_battle(a, b, level=params.level, seed=params.seed, max_turns=params.maxTurns)
+def simulate_battle_tool(
+    pokemonA: str,
+    pokemonB: str,
+    level: int = 50,
+    seed: int = 42,
+    maxTurns: int = 200,
+) -> SimulateResponse:
+    """Simulate a battle between two Pokémon.
+
+    Args:
+        pokemonA: Name of the first Pokémon.
+        pokemonB: Name of the second Pokémon.
+        level: Battle level (1-100).
+        seed: RNG seed for determinism.
+        maxTurns: Maximum number of turns to simulate.
+    """
+
+    req = SimulateRequest(
+        pokemonA=pokemonA,
+        pokemonB=pokemonB,
+        level=level,
+        seed=seed,
+        maxTurns=maxTurns,
+    )
+
+    a = get_pokemon(req.pokemonA)
+    b = get_pokemon(req.pokemonB)
+    result = simulate_battle(
+        a, b, level=req.level, seed=req.seed, max_turns=req.maxTurns
+    )
     return SimulateResponse(**result)

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ from core.repository import get_evolution, get_move, get_pokemon, list_pokemon
 
 try:
     # Pydantic v2 models preferred
-    from pokemon_mcp.schemas import PokemonDetail, PokemonSummary, SimulateRequest
+    from pokemon_mcp.schemas import PokemonDetail, PokemonSummary
     V2 = hasattr(PokemonDetail, "model_dump")
 except Exception:
     raise
@@ -60,15 +60,24 @@ async def get_pokemon_resource(id: str) -> dict:
 
 
 @server.tool(name="simulate_battle")
-async def simulate_battle(params: SimulateRequest) -> dict:
+async def simulate_battle(
+    pokemonA: str,
+    pokemonB: str,
+    level: int = 50,
+    seed: int = 42,
+    maxTurns: int = 200,
+) -> dict:
     """Run a battle simulation and return structured JSON."""
     from pokemon_mcp.tools import simulate_battle_tool
 
-    # Apply defaults via the Pydantic model
-    req = SimulateRequest(**params.model_dump())  # ensures defaults for missing fields
-
     try:
-        res = simulate_battle_tool(req)
+        res = simulate_battle_tool(
+            pokemonA=pokemonA,
+            pokemonB=pokemonB,
+            level=level,
+            seed=seed,
+            maxTurns=maxTurns,
+        )
     except Exception as e:  # pragma: no cover - surface as ValueError
         suggestions = [p["name"] for p in list_pokemon()[:2]]
         raise ValueError(
@@ -86,7 +95,7 @@ async def simulate_battle(params: SimulateRequest) -> dict:
 def battle_strategy(pokemonA: str, pokemonB: str) -> list[AssistantMessage]:
     """Generate battle strategies for two Pokémon via OpenAI."""
     response = openai.chat.completions.create(
-        model="gpt-5-mini",
+        model="gpt-4.1-mini",
         messages=[
             {
                 "role": "system",
@@ -99,6 +108,45 @@ def battle_strategy(pokemonA: str, pokemonB: str) -> list[AssistantMessage]:
                     "Provide type effectiveness, possible move choices, status effects, and a likely winner."
                 ),
             },
+        ],
+    )
+    content = response.choices[0].message.content
+    return [AssistantMessage(content=content)]
+
+
+@server.prompt("type-effectiveness")
+def type_effectiveness(pokemon_type: str, against_type: str) -> list[AssistantMessage]:
+    """Explain how effective one Pokémon type is against another."""
+    response = openai.chat.completions.create(
+        model="gpt-4.1-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a Pokémon type matchup expert.",
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"How effective are {pokemon_type} moves against {against_type} types?"
+                ),
+            },
+        ],
+    )
+    content = response.choices[0].message.content
+    return [AssistantMessage(content=content)]
+
+
+@server.prompt("pokemon-fact")
+def pokemon_fact(name: str) -> list[AssistantMessage]:
+    """Provide a fun fact about a given Pokémon."""
+    response = openai.chat.completions.create(
+        model="gpt-4.1-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": "You share concise and interesting Pokémon trivia.",
+            },
+            {"role": "user", "content": f"Give a fun fact about {name}."},
         ],
     )
     content = response.choices[0].message.content

--- a/simulate_battle.py
+++ b/simulate_battle.py
@@ -1,7 +1,6 @@
 import argparse
 
 from pokemon_mcp.tools import simulate_battle_tool
-from pokemon_mcp.schemas import SimulateRequest
 
 
 def main() -> None:
@@ -19,14 +18,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    req = SimulateRequest(
+    res = simulate_battle_tool(
         pokemonA=args.pokemonA,
         pokemonB=args.pokemonB,
         level=args.level,
         seed=args.seed,
         maxTurns=args.max_turns,
     )
-    res = simulate_battle_tool(req)
 
     print(f"Winner: {res.winner} after {res.turns} turns")
     for entry in res.log:

--- a/tests/test_simulate_api.py
+++ b/tests/test_simulate_api.py
@@ -1,10 +1,8 @@
-from pokemon_mcp.schemas import SimulateRequest
 from pokemon_mcp.tools import simulate_battle_tool
 
 
 def test_simulate_battle_api():
-    req = SimulateRequest(pokemonA="Pikachu", pokemonB="Squirtle", seed=42)
-    res = simulate_battle_tool(req)
+    res = simulate_battle_tool(pokemonA="Pikachu", pokemonB="Squirtle", seed=42)
     assert res.winner == "Pikachu"
     assert res.turns == 1
     assert len(res.log) == 1


### PR DESCRIPTION
## Summary
- expose `simulate_battle` tool with direct arguments instead of a wrapped `params` object
- standardize on `gpt-4.1-mini` and add reusable prompts for type matchups and fun facts
- update prompt-tab guidance and docs for unwrapped tool arguments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b0807204832da8e5580e046bd486