### PR TITLE
Add OpenAI provider config and env scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 mcp-pokemon.zip
+.env
+.openai_key
+*.local.yaml

--- a/.mcp/providers.yaml
+++ b/.mcp/providers.yaml
@@ -1,0 +1,7 @@
+providers:
+  openai:
+    baseUrl: https://api.openai.com/v1
+    apiKey: ${OPENAI_API_KEY}
+    models:
+      - id: gpt-4.1-mini
+        toolCalling: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ pip install -r requirements.txt
 pytest
 ```
 
+## Provider setup
+
+Option A (recommended):
+
+```bash
+cp .env.example .env
+# then put your key:
+echo 'OPENAI_API_KEY=sk-...' >> .env
+```
+
+Start Inspector from a shell that loads `.env`.
+
+Option B:
+
+```bash
+echo 'sk-...' > .openai_key
+export OPENAI_API_KEY="$(cat .openai_key)"
+```
+
+In MCP Inspector, if there is a "Providers/Clients File" picker, point it at `.mcp/providers.yaml`.
+
+Set the active chat model in MCP Inspector (Sampling/Elicitations or Settings) to `gpt-4.1-mini` and ensure tool/function-calling is enabled for this workspace.
+
 ## Running the server
 
 Start the MCP server which exposes the Pokémon data resource and battle


### PR DESCRIPTION
## Summary
- Configure `.mcp/providers.yaml` for the OpenAI provider using `OPENAI_API_KEY` and enable tool-calling for `gpt-4.1-mini`
- Add `.env.example` and document provider setup and model selection in README
- Ignore local environment key files in `.gitignore`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1cda98e9c832dbf10423ebf10deb7